### PR TITLE
remove exact from route

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ class App extends Component {
         <Router>
           <div>
             <Link to="/admin">Admin</Link>
-            <Route path="/admin" exact component={Admin}/>
+            <Route path="/admin" component={Admin}/>
           </div>
         </Router>
       </div>


### PR DESCRIPTION
- Remove "exact" from the routing tag so it doesn't always navigate back to the admin page.