### PR TITLE
Update SearchProviders page filter column

### DIFF
--- a/src/components/SearchProviders/ServiceProviderFilter.js
+++ b/src/components/SearchProviders/ServiceProviderFilter.js
@@ -6,7 +6,7 @@ const ServiceProviderFilter = ({serviceQuestions,Criteria,add_Criteria}) =>
         <h4>Filters</h4>
         <br/>
         {
-            serviceQuestions.map(question =>
+            Array.from(serviceQuestions).map(question =>
                 <ServiceQuestion
                     serviceQuestion={question}
                     Criteria = {Criteria}

--- a/src/components/SearchProviders/ServiceProviderNavigatorContainer.js
+++ b/src/components/SearchProviders/ServiceProviderNavigatorContainer.js
@@ -2,19 +2,52 @@ import React from "react";
 import ServiceProviderNavigator from "./ServiceProviderNavigator";
 import ServiceProviders from "../../test/MockData/Users.mock";
 import serviceCategories from '../../test/MockData/ServiceCategories.mock'
-import serviceQuestions from '../../test/MockData/ServiceQuestion.mock'
 import ServiceQuestions from "../ServiceQuestions";
+import ServiceService from '../../services/ServiceService';
+import ServiceQuestionService from '../../services/ServiceQuestionService';
+{/* import serviceQuestions from '../../test/MockData/ServiceQuestion.mock' 
+import ServiceQuestions from "../ServiceQuestions";
+import ServiceService from '../../services/ServiceService';*/}
 
 
 class ServiceProviderNavigatorContainer extends React.Component {
     constructor(props) {
         super(props)
+        {/* SERVICE SELECTED HARD CODED FOR NOW */}
+        this.serviceQuestionService = ServiceQuestionService.getInstance()
+        this.service = 123
         this.state = {
-            questions: serviceQuestions,
-            criteria : new Array(serviceQuestions.length)
+            questions: [],
+            criteria: []
     }
     this.add_Criteria = this.add_Criteria.bind(this)
+    this.componentDidMount = this.componentDidMount.bind(this)
     }
+
+    componentDidMount() {
+        this.serviceQuestionService.findAllServiceQuestionsByServiceId(this.service).then((questions) => {
+            var serviceQuestions = questions
+            console.log(serviceQuestions)
+            console.log(serviceQuestions[0])
+            console.log(serviceQuestions[1])
+            serviceQuestions.map(function(question){
+                question.choices = question.choices.split(',')
+            })
+        
+            this.setState({
+                questions: serviceQuestions,
+                criteria: new Array(serviceQuestions.length)
+            })
+        })
+
+    }
+
+    updateQuestions = (service_id) => this.serviceQuestionService
+                                .findAllServiceQuestionsByServiceId(service_id)
+                                .then(questions =>
+                                    this.setState({
+                                        questions: questions
+                                    }));
 
 
     add_Criteria = e =>

--- a/src/services/ServiceQuestionService.js
+++ b/src/services/ServiceQuestionService.js
@@ -18,6 +18,10 @@ export default class ServiceQuestionService {
         fetch(`${this.backend_url}/api/service-questions`)
             .then(response => response.json())
 
+    findAllServiceQuestionsByServiceId = (serviceId) =>
+        fetch(`${this.backend_url}/api/service-questions/service/${serviceId}`)
+            .then(response => response.json())
+
     createQuestion = (question) =>
         fetch(`${this.backend_url}/api/service-questions`,
         {


### PR DESCRIPTION
SearchProviders page now no longer uses mock data. Added a fetch to the
ServiceQuestionService to grab the questions for a given service id. The
searchproviders page populates the filters from the questions retrieved
from there, after doing some basic parsing on the choices in the
questions, transforming from a comma separated string to an array.